### PR TITLE
Update pjlink.class.php

### DIFF
--- a/pjlink.class.php
+++ b/pjlink.class.php
@@ -304,7 +304,7 @@ class PJLink
 
 		stream_set_timeout($this->socket, $this->timeout, 0);
 
-		$response = $this->getResponse();
+		$response = strtoupper($this->getResponse());
 
 		if (FALSE !== strpos($response, "PJLINK 0")) {
 			$this->prefix_hash = "";


### PR DESCRIPTION
Some projectors may response in lower case text. If that happens connection fails, so I make it case insensitive. 